### PR TITLE
misspelling fix in maas parse file path

### DIFF
--- a/cluster_metrics/playbook-influx-telegraf.yml
+++ b/cluster_metrics/playbook-influx-telegraf.yml
@@ -99,9 +99,9 @@
     commands : []
     command_plugins:
       keystone:
-        plugin_name: "maas_ouput_parser.py"
+        plugin_name: "maas_output_parser.py"
         command:
-          - "python /opt/telegraf/maas_ouput_parser.py keystone_api /opt/reliability-rpc-openstack/maas/plugins/keystone_api_local_check.py"
+          - "python /opt/telegraf/maas_output_parser.py keystone_api /opt/reliability-rpc-openstack/maas/plugins/keystone_api_local_check.py"
         group: "utility_all"
         when_group: "{{ (groups['utility_all'] | length) > 0 }}"
       cinder:


### PR DESCRIPTION
The misspelling was causing the telegraf colector
to fail